### PR TITLE
Pass all extra parameters from receive_from_*/send_from_* onto give/get.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,41 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
+    "rules": {
+        "space-infix-ops": "error",
+        "prefer-const": "error",
+        "comma-spacing": [
+          2, {
+            "before": false,
+            "after": true
+          }
+        ],
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/demo/strings/ascii.js
+++ b/demo/strings/ascii.js
@@ -7,10 +7,10 @@ const to_array = function (ascii) {
     array[i] = ascii[i].charCodeAt();
   }
   return array;
-}
+};
 const to_ascii = function (array) {
   return String.fromCharCode.apply(null, array);
-}
+};
 
 module.exports = {
   to_array: to_array,

--- a/demo/strings/example.js
+++ b/demo/strings/example.js
@@ -5,10 +5,12 @@ const ascii = require('./ascii.js');
  *  the methods in IO to send public messages between the two parties.
  */
 var IO = require('../io-example.js');
-const OT = require('1-out-of-n')(IO);
+const OT = require('../../index.js')(IO);
 const N = 11;
 const op_id = '1in11ot';  // OPTIONAL op_id string
 const session_id = '1,2';  // OPTIONAL string to specify participants
+const extra_arg_1 = "str_1";  // OPTIONAL extra parameters
+const extra_arg_2 = "str_2";  // (We can pass multiple, if needed for the IO.)
 
 OT.then(function (OT) {
 
@@ -29,13 +31,13 @@ OT.then(function (OT) {
     'A tenth secret!!'
   ].map(ascii.to_array);
 
-  OT.send(secrets, N, op_id, session_id);
+  OT.send(secrets, N, op_id, session_id, extra_arg_1, extra_arg_2);
 
 
   /*
    *  The receiver calls:
    */
-  OT.receive(6, N, op_id, session_id).then(function (array) {
+  OT.receive(6, N, op_id, session_id, extra_arg_1, extra_arg_2).then(function (array) {
     console.log('The chosen secret is:', ascii.to_ascii(array));
   });
 

--- a/lib/ot.js
+++ b/lib/ot.js
@@ -5,8 +5,9 @@ module.exports = function (io, sodium) {
   // 1-out-of-2 OT sending
   const send_from_2 = function (X1, X2, op_id, session_id) {
     op_id = op_id + ':1in2ot';
-    var get = io.get.bind(null, op_id, session_id);
-    var give = io.give.bind(null, op_id, session_id);
+    let args = Array.prototype.slice.call(arguments, 4);
+    var get = io.get.bind(null, op_id, session_id, args);
+    var give = io.give.bind(null, op_id, session_id, args);
 
     const a = sodium.crypto_core_ristretto255_scalar_random();
     const A = sodium.crypto_scalarmult_ristretto255_base(a);
@@ -31,8 +32,9 @@ module.exports = function (io, sodium) {
   // 1-out-of-2 OT receiving
   const receive_from_2 = function (c, op_id, session_id) {
     op_id = op_id + ':1in2ot';
-    var get = io.get.bind(null, op_id, session_id);
-    var give = io.give.bind(null, op_id, session_id);
+    let args = Array.prototype.slice.call(arguments, 3);
+    var get = io.get.bind(null, op_id, session_id, args);
+    var give = io.give.bind(null, op_id, session_id, args);
 
     const b = sodium.crypto_core_ristretto255_scalar_random();
     var B = sodium.crypto_scalarmult_ristretto255_base(b);
@@ -65,7 +67,8 @@ module.exports = function (io, sodium) {
   const send_from_N = function (X, N, op_id, session_id) {
     var I, j;
     op_id = op_id + ':1inNot';
-    var give = io.give.bind(null, op_id, session_id);
+    let args = Array.prototype.slice.call(arguments, 4);
+    var give = io.give.bind(null, op_id, session_id, args);
     X = util.sanitize(X);  // Check padding and fix if not the right type
 
     if (N == null) {
@@ -109,7 +112,8 @@ module.exports = function (io, sodium) {
   const receive_from_N = function (I, N, op_id, session_id) {
     var j;
     op_id = op_id + ':1inNot';
-    var get = io.get.bind(null, op_id, session_id);
+    let args = Array.prototype.slice.call(arguments, 4);
+    var get = io.get.bind(null, op_id, session_id, args);
 
     return new Promise(function (resolve) {
       const l = Math.ceil(Math.log2(N));  // N = 2^l

--- a/lib/ot.js
+++ b/lib/ot.js
@@ -5,9 +5,9 @@ module.exports = function (io, sodium) {
   // 1-out-of-2 OT sending
   const send_from_2 = function (X1, X2, op_id, session_id) {
     op_id = op_id + ':1in2ot';
-    let args = Array.prototype.slice.call(arguments, 4);
-    var get = io.get.bind(null, op_id, session_id, args);
-    var give = io.give.bind(null, op_id, session_id, args);
+    let args = Array.prototype.slice.call(arguments, 2);
+    var get = io.get.bind(null, args);
+    var give = io.give.bind(null, args);
 
     const a = sodium.crypto_core_ristretto255_scalar_random();
     const A = sodium.crypto_scalarmult_ristretto255_base(a);
@@ -32,9 +32,9 @@ module.exports = function (io, sodium) {
   // 1-out-of-2 OT receiving
   const receive_from_2 = function (c, op_id, session_id) {
     op_id = op_id + ':1in2ot';
-    let args = Array.prototype.slice.call(arguments, 3);
-    var get = io.get.bind(null, op_id, session_id, args);
-    var give = io.give.bind(null, op_id, session_id, args);
+    let args = Array.prototype.slice.call(arguments, 1);
+    var get = io.get.bind(null, args);
+    var give = io.give.bind(null, args);
 
     const b = sodium.crypto_core_ristretto255_scalar_random();
     var B = sodium.crypto_scalarmult_ristretto255_base(b);
@@ -67,8 +67,8 @@ module.exports = function (io, sodium) {
   const send_from_N = function (X, N, op_id, session_id) {
     var I, j;
     op_id = op_id + ':1inNot';
-    let args = Array.prototype.slice.call(arguments, 4);
-    var give = io.give.bind(null, op_id, session_id, args);
+    let args = Array.prototype.slice.call(arguments, 2);
+    var give = io.give.bind(null, args);
     X = util.sanitize(X);  // Check padding and fix if not the right type
 
     if (N == null) {
@@ -112,8 +112,8 @@ module.exports = function (io, sodium) {
   const receive_from_N = function (I, N, op_id, session_id) {
     var j;
     op_id = op_id + ':1inNot';
-    let args = Array.prototype.slice.call(arguments, 4);
-    var get = io.get.bind(null, op_id, session_id, args);
+    let args = Array.prototype.slice.call(arguments, 2);
+    var get = io.get.bind(null, args);
 
     return new Promise(function (resolve) {
       const l = Math.ceil(Math.log2(N));  // N = 2^l

--- a/lib/ot.js
+++ b/lib/ot.js
@@ -2,11 +2,20 @@ module.exports = function (io, sodium) {
   const util = require('./util.js')(sodium);
   const crypto = require('./crypto.js')(sodium, util);
 
+  // helper to allow automatic integration for socket's other parameters
+  const end_bind = function (fn, end_args) {
+    return (function (end_args) {
+      return fn.apply(this, Array.from(arguments).slice(1).concat(end_args));
+    }).bind(this, end_args);
+  };
+
   // 1-out-of-2 OT sending
   const send_from_2 = function (X1, X2, op_id, session_id) {
+    const extra_args = Array.from(arguments).slice(4);
+
     op_id = op_id + ':1in2ot';
-    var get = io.get.bind(null, op_id, session_id, arguments[4]);// arguments[4] means extra parameters
-    var give = io.give.bind(null, op_id, session_id, arguments[4]);
+    var get = end_bind(io.get.bind(null, op_id, session_id), extra_args);  // extra_args means extra parameters
+    var give = end_bind(io.give.bind(null, op_id, session_id), extra_args);
 
     const a = sodium.crypto_core_ristretto255_scalar_random();
     const A = sodium.crypto_scalarmult_ristretto255_base(a);
@@ -30,11 +39,11 @@ module.exports = function (io, sodium) {
 
   // 1-out-of-2 OT receiving
   const receive_from_2 = function (c, op_id, session_id) {
+    const extra_args = Array.from(arguments).slice(3);
 
     op_id = op_id + ':1in2ot';
-    var get = io.get.bind(null, op_id, session_id, arguments[3]);
-    var give = io.give.bind(null, op_id, session_id, arguments[3]);
-
+    var get = end_bind(io.get.bind(null, op_id, session_id), extra_args);
+    var give = end_bind(io.give.bind(null, op_id, session_id), extra_args);
 
     const b = sodium.crypto_core_ristretto255_scalar_random();
     var B = sodium.crypto_scalarmult_ristretto255_base(b);
@@ -66,10 +75,12 @@ module.exports = function (io, sodium) {
   // 1-out-of-2 OT sending
   const send_from_N = function (X, N, op_id, session_id) {
     var I, j;
-    op_id = op_id + ':1inNot';
-    var args = Array.prototype.slice.call(arguments, 4);  //extra parameters
 
-    var give = io.give.bind(null, op_id, session_id, args);
+    const extra_args = Array.from(arguments).slice(4);
+
+    op_id = op_id + ':1inNot';
+    var give = end_bind(io.give.bind(null, op_id, session_id), extra_args);
+    var __send_from_2 = end_bind(send_from_2, extra_args);
     X = util.sanitize(X);  // Check padding and fix if not the right type
 
     if (N == null) {
@@ -100,7 +111,7 @@ module.exports = function (io, sodium) {
     }
     for (j = 0; j < l; j++) {
       const K_j = K[j];
-      send_from_2(K_j[0], K_j[1], op_id + j, session_id, args);
+      __send_from_2(K_j[0], K_j[1], op_id + j, session_id);
     }
 
     for (I = 0; I < N; I++) {
@@ -111,9 +122,13 @@ module.exports = function (io, sodium) {
   // 1-out-of-2 OT receiving
   const receive_from_N = function (I, N, op_id, session_id) {
     var j;
+
+    const extra_args = Array.from(arguments).slice(4);
+
     op_id = op_id + ':1inNot';
-    const args = Array.prototype.slice.call(arguments, 4);
-    var get = io.get.bind(null, op_id, session_id, args);
+    var get = end_bind(io.get.bind(null, op_id, session_id), extra_args);
+    var __receive_from_2 = end_bind(receive_from_2, extra_args);
+
     return new Promise(function (resolve) {
       const l = Math.ceil(Math.log2(N));  // N = 2^l
       const i = util.to_bits(I, l);  // l bits of I
@@ -121,7 +136,7 @@ module.exports = function (io, sodium) {
       var K = Array(l);
       for (j = 0; j < l; j++) {
         const i_j = i[j];  // bit j=i_j of I
-        K[j] = receive_from_2(i_j, op_id + j, session_id, args);  // pick {K_{j}}^{b} which is also {K_{j}}^{i_j}
+        K[j] = __receive_from_2(i_j, op_id + j, session_id);  // pick {K_{j}}^{b} which is also {K_{j}}^{i_j}
       }
 
       Promise.all(K).then(function (K) {

--- a/lib/ot.js
+++ b/lib/ot.js
@@ -5,9 +5,8 @@ module.exports = function (io, sodium) {
   // 1-out-of-2 OT sending
   const send_from_2 = function (X1, X2, op_id, session_id) {
     op_id = op_id + ':1in2ot';
-    let args = Array.prototype.slice.call(arguments, 2);
-    var get = io.get.bind(null, args);
-    var give = io.give.bind(null, args);
+    var get = io.get.bind(null,op_id, session_id,arguments[4]);// arguments[4] means extra parameters
+    var give = io.give.bind(null,op_id, session_id,arguments[4]);
 
     const a = sodium.crypto_core_ristretto255_scalar_random();
     const A = sodium.crypto_scalarmult_ristretto255_base(a);
@@ -31,10 +30,11 @@ module.exports = function (io, sodium) {
 
   // 1-out-of-2 OT receiving
   const receive_from_2 = function (c, op_id, session_id) {
+
     op_id = op_id + ':1in2ot';
-    let args = Array.prototype.slice.call(arguments, 1);
-    var get = io.get.bind(null, args);
-    var give = io.give.bind(null, args);
+    var get = io.get.bind(null,op_id, session_id,arguments[3]);
+    var give = io.give.bind(null,op_id, session_id,arguments[3]);
+
 
     const b = sodium.crypto_core_ristretto255_scalar_random();
     var B = sodium.crypto_scalarmult_ristretto255_base(b);
@@ -67,8 +67,9 @@ module.exports = function (io, sodium) {
   const send_from_N = function (X, N, op_id, session_id) {
     var I, j;
     op_id = op_id + ':1inNot';
-    let args = Array.prototype.slice.call(arguments, 2);
-    var give = io.give.bind(null, args);
+    let args= Array.prototype.slice.call(arguments,4);  //extra parameters
+
+    var give = io.give.bind(null, op_id, session_id,args);
     X = util.sanitize(X);  // Check padding and fix if not the right type
 
     if (N == null) {
@@ -97,10 +98,9 @@ module.exports = function (io, sodium) {
         Y[I] = util.xor(Y[I], crypto.PRF(Kj_ij, I));
       }
     }
-
     for (j = 0; j < l; j++) {
       const K_j = K[j];
-      send_from_2(K_j[0], K_j[1], op_id+j, session_id);
+      send_from_2(K_j[0], K_j[1], op_id+j, session_id,args);
     }
 
     for (I = 0; I < N; I++) {
@@ -112,9 +112,8 @@ module.exports = function (io, sodium) {
   const receive_from_N = function (I, N, op_id, session_id) {
     var j;
     op_id = op_id + ':1inNot';
-    let args = Array.prototype.slice.call(arguments, 2);
-    var get = io.get.bind(null, args);
-
+    let args= Array.prototype.slice.call(arguments,4);
+    var get = io.get.bind(null,op_id, session_id,args);
     return new Promise(function (resolve) {
       const l = Math.ceil(Math.log2(N));  // N = 2^l
       const i = util.to_bits(I, l);  // l bits of I
@@ -122,7 +121,7 @@ module.exports = function (io, sodium) {
       var K = Array(l);
       for (j = 0; j < l; j++) {
         const i_j = i[j];  // bit j=i_j of I
-        K[j] = receive_from_2(i_j, op_id+j, session_id);  // pick {K_{j}}^{b} which is also {K_{j}}^{i_j}
+        K[j] = receive_from_2(i_j, op_id+j, session_id,args);  // pick {K_{j}}^{b} which is also {K_{j}}^{i_j}
       }
 
       Promise.all(K).then(function (K) {

--- a/lib/ot.js
+++ b/lib/ot.js
@@ -5,8 +5,8 @@ module.exports = function (io, sodium) {
   // 1-out-of-2 OT sending
   const send_from_2 = function (X1, X2, op_id, session_id) {
     op_id = op_id + ':1in2ot';
-    var get = io.get.bind(null,op_id, session_id,arguments[4]);// arguments[4] means extra parameters
-    var give = io.give.bind(null,op_id, session_id,arguments[4]);
+    var get = io.get.bind(null, op_id, session_id, arguments[4]);// arguments[4] means extra parameters
+    var give = io.give.bind(null, op_id, session_id, arguments[4]);
 
     const a = sodium.crypto_core_ristretto255_scalar_random();
     const A = sodium.crypto_scalarmult_ristretto255_base(a);
@@ -32,8 +32,8 @@ module.exports = function (io, sodium) {
   const receive_from_2 = function (c, op_id, session_id) {
 
     op_id = op_id + ':1in2ot';
-    var get = io.get.bind(null,op_id, session_id,arguments[3]);
-    var give = io.give.bind(null,op_id, session_id,arguments[3]);
+    var get = io.get.bind(null, op_id, session_id, arguments[3]);
+    var give = io.give.bind(null, op_id, session_id, arguments[3]);
 
 
     const b = sodium.crypto_core_ristretto255_scalar_random();
@@ -67,9 +67,9 @@ module.exports = function (io, sodium) {
   const send_from_N = function (X, N, op_id, session_id) {
     var I, j;
     op_id = op_id + ':1inNot';
-    let args= Array.prototype.slice.call(arguments,4);  //extra parameters
+    var args = Array.prototype.slice.call(arguments, 4);  //extra parameters
 
-    var give = io.give.bind(null, op_id, session_id,args);
+    var give = io.give.bind(null, op_id, session_id, args);
     X = util.sanitize(X);  // Check padding and fix if not the right type
 
     if (N == null) {
@@ -100,7 +100,7 @@ module.exports = function (io, sodium) {
     }
     for (j = 0; j < l; j++) {
       const K_j = K[j];
-      send_from_2(K_j[0], K_j[1], op_id+j, session_id,args);
+      send_from_2(K_j[0], K_j[1], op_id + j, session_id, args);
     }
 
     for (I = 0; I < N; I++) {
@@ -112,8 +112,8 @@ module.exports = function (io, sodium) {
   const receive_from_N = function (I, N, op_id, session_id) {
     var j;
     op_id = op_id + ':1inNot';
-    let args= Array.prototype.slice.call(arguments,4);
-    var get = io.get.bind(null,op_id, session_id,args);
+    const args = Array.prototype.slice.call(arguments, 4);
+    var get = io.get.bind(null, op_id, session_id, args);
     return new Promise(function (resolve) {
       const l = Math.ceil(Math.log2(N));  // N = 2^l
       const i = util.to_bits(I, l);  // l bits of I
@@ -121,7 +121,7 @@ module.exports = function (io, sodium) {
       var K = Array(l);
       for (j = 0; j < l; j++) {
         const i_j = i[j];  // bit j=i_j of I
-        K[j] = receive_from_2(i_j, op_id+j, session_id,args);  // pick {K_{j}}^{b} which is also {K_{j}}^{i_j}
+        K[j] = receive_from_2(i_j, op_id + j, session_id, args);  // pick {K_{j}}^{b} which is also {K_{j}}^{i_j}
       }
 
       Promise.all(K).then(function (K) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -35,7 +35,7 @@ module.exports = function (sodium) {
   };
   const from_str = function (str) {
     if (str.indexOf(del) > 1) {
-      json_array = '["' + str.split(del).join('","') + '"]';
+      var json_array = '["' + str.split(del).join('","') + '"]';
       return JSON.parse(json_array).map(from_str);
     } else {
       return to_Uint8(str);
@@ -46,21 +46,23 @@ module.exports = function (sodium) {
   const sanitize = function (X, l) {
     if (Array.isArray(X) && X.length > 0 && typeof(X[0]) === 'number') {
       if (l == null) {
-        const max = function (x, y) { return x > y ? x : y; };
+        const max = function (x, y) {
+          return x > y ? x : y;
+        };
         const x_max = X.reduce(max, 0);
-        l = Math.ceil(Math.log2(x_max+1)/8);  // the minimum bytes required
+        l = Math.ceil(Math.log2(x_max + 1) / 8);  // the minimum bytes required
       }
       for (var i = 0; i < X.length; i++) {
         var n = X[i];
         X[i] = new Uint8Array(l);
         for (var j = 0; j < l; j++) {
           X[i][j] = n % 256;
-          n = Math.floor(n/256);
+          n = Math.floor(n / 256);
         }
       }
     }
     return X;
-  }
+  };
 
   return {
     to_bits: to_bits,
@@ -69,4 +71,4 @@ module.exports = function (sodium) {
     from_str: from_str,
     sanitize: sanitize
   };
-}
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "lib/util.js"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint lib",
+    "lint-fix": "eslint lib --fix",
+    "lint-all": "eslint .",
+    "lint-all-fix": "eslint lib --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
slice arguments list after session_id/op_id and pass remaining un-named arguments onto give/get.

@wyatt-howe thought this might make integration w/ JIFF easier (can pass jiff object as extra parameter, or associated to/from information). The rest parameter syntax (e.g. `func(...args)`) is only ES6 specific which is why I used the arguments parameter instead. Curious to see if you think this is reasonable and does not change the package too drastically.